### PR TITLE
Fixed examples for pycallgraph2

### DIFF
--- a/examples/graphviz/all.py
+++ b/examples/graphviz/all.py
@@ -8,7 +8,7 @@ import os
 
 curdir = os.path.dirname(os.path.abspath(__file__))
 examples = glob(os.path.join(curdir, '*.py'))
-examples.remove(os.path.join(curdir,'all.py'))
+examples.remove(os.path.join(curdir, 'all.py'))
 for example in examples:
     print(example)
     execfile(example)

--- a/examples/graphviz/all.py
+++ b/examples/graphviz/all.py
@@ -3,10 +3,12 @@
 Execute all pycallgraph examples in this directory.
 '''
 from glob import glob
+import os
 
 
-examples = glob('*.py')
-examples.remove('all.py')
+curdir = os.path.dirname(os.path.abspath(__file__))
+examples = glob(os.path.join(curdir, '*.py'))
+examples.remove(os.path.join(curdir,'all.py'))
 for example in examples:
     print(example)
     execfile(example)

--- a/examples/graphviz/basic.py
+++ b/examples/graphviz/basic.py
@@ -2,8 +2,8 @@
 '''
 This example demonstrates a simple use of pycallgraph.
 '''
-from pycallgraph import PyCallGraph
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2.output import GraphvizOutput
 
 
 class Banana:

--- a/examples/graphviz/colors.py
+++ b/examples/graphviz/colors.py
@@ -7,10 +7,10 @@ how to return colour formats to Graphviz.
 '''
 import random
 
-from pycallgraph import PyCallGraph
-from pycallgraph import Config
-from pycallgraph import Color
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2 import Config
+from pycallgraph2 import Color
+from pycallgraph2.output import GraphvizOutput
 
 
 def rainbow(node):

--- a/examples/graphviz/example_with_submodules/example_with_submodules.py
+++ b/examples/graphviz/example_with_submodules/example_with_submodules.py
@@ -9,5 +9,6 @@ def main():
     s2 = SubmoduleTwo()
     s2.report()
 
+
 if __name__ == "__main__":
     main()

--- a/examples/graphviz/filter.py
+++ b/examples/graphviz/filter.py
@@ -4,10 +4,10 @@ This example demonstrates the use of filtering.
 '''
 import time
 
-from pycallgraph import PyCallGraph
-from pycallgraph import Config
-from pycallgraph import GlobbingFilter
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2 import Config
+from pycallgraph2 import GlobbingFilter
+from pycallgraph2.output import GraphvizOutput
 
 
 class Banana:

--- a/examples/graphviz/grouper.py
+++ b/examples/graphviz/grouper.py
@@ -2,11 +2,11 @@
 '''
 This example demonstrates the use of grouping.
 '''
-from pycallgraph import PyCallGraph
-from pycallgraph import Config
-from pycallgraph import GlobbingFilter
-from pycallgraph import Grouper
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2 import Config
+from pycallgraph2 import GlobbingFilter
+from pycallgraph2 import Grouper
+from pycallgraph2.output import GraphvizOutput
 import example_with_submodules
 
 

--- a/examples/graphviz/import.py
+++ b/examples/graphviz/import.py
@@ -3,9 +3,9 @@
 This example shows the interals of certain Python modules when they are being
 imported.
 '''
-from pycallgraph import PyCallGraph
-from pycallgraph import Config
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2 import Config
+from pycallgraph2.output import GraphvizOutput
 
 
 def main():

--- a/examples/graphviz/large.py
+++ b/examples/graphviz/large.py
@@ -4,9 +4,9 @@ This example is trying to make a large graph. You'll need some internet access
 for this to work.
 '''
 
-from pycallgraph import PyCallGraph
-from pycallgraph import Config
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2 import Config
+from pycallgraph2.output import GraphvizOutput
 
 
 def main():

--- a/examples/graphviz/recursive.py
+++ b/examples/graphviz/recursive.py
@@ -20,5 +20,6 @@ def main():
         for a in xrange(1, 10):
             factorial(a)
 
+
 if __name__ == '__main__':
     main()

--- a/examples/graphviz/recursive.py
+++ b/examples/graphviz/recursive.py
@@ -2,8 +2,8 @@
 '''
 This example demonstrates a simple recursive call.
 '''
-from pycallgraph import PyCallGraph
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2.output import GraphvizOutput
 
 
 def factorial(n):

--- a/examples/graphviz/regexp.py
+++ b/examples/graphviz/regexp.py
@@ -41,5 +41,6 @@ def words():
         'abrasives',
     ]
 
+
 if __name__ == '__main__':
     main()

--- a/examples/graphviz/regexp.py
+++ b/examples/graphviz/regexp.py
@@ -4,9 +4,9 @@ This example demonstrates the internal workings of a regular expression lookup.
 '''
 import re
 
-from pycallgraph import PyCallGraph
-from pycallgraph import Config
-from pycallgraph.output import GraphvizOutput
+from pycallgraph2 import PyCallGraph
+from pycallgraph2 import Config
+from pycallgraph2.output import GraphvizOutput
 
 
 def main():


### PR DESCRIPTION
This patch fixes the pycallgraph2 imports in graphiz examples and allows running the examples from any directory. There's a couple of py2 flake8 fixes too.

I ran all the graphviz examples locally and successfully on Ubuntu Disco (dev release) 