### PR TITLE
Changing default output format from `.png` to `.svg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Installation is easy as:
 
     pip install pycallgraph2
 
-The following examples specify graphviz as the outputter, so it's required to be installed. They will generate a file called `pycallgraph.png`.
+The following examples specify graphviz as the outputter, so it's required to be installed. They will generate a file called `pycallgraph.svg`.
 
 The command-line method of running pycallgraph is::
 

--- a/pycallgraph2/output/graphviz.py
+++ b/pycallgraph2/output/graphviz.py
@@ -15,8 +15,8 @@ class GraphvizOutput(Output):
 
     def __init__(self, **kwargs):
         self.tool = 'dot'
-        self.output_file = 'pycallgraph.png'
-        self.output_type = 'png'
+        self.output_file = 'pycallgraph.svg'
+        self.output_type = 'svg'
         self.font_name = 'Verdana'
         self.font_size = 7
         self.group_font_size = 10


### PR DESCRIPTION
Changes:
- changed output format of graphviz.py from png --> svg
- renamed mention of output file in README.md accordingly

Explanation:
svg (scalable vector graphics) usually lead to a smaller file, while at the same time the fact of being a scalable image format, rather than rasterized, prevents pixalation. I think it should be default file format for such an application, as the graph might get pretty big, depending on the project one tries to inspect with it.

I've seen a few libraries outputting ~10MB .pngs with "nothing to see there" anyway. (The output I got with pycallgraph2 was ~1MB and readable, but pixalated.)

Thanks for maintaining this library. :)