### PR TITLE
remove extra quationation marks to avoid silent failure on windows

### DIFF
--- a/pycallgraph2/output/graphviz.py
+++ b/pycallgraph2/output/graphviz.py
@@ -98,7 +98,7 @@ class GraphvizOutput(Output):
         with os.fdopen(fd, 'w') as f:
             f.write(source)
 
-        cmd = '"{0}" -T{1} -o{2} {3}'.format(
+        cmd = '{0} -T{1} -o{2} {3}'.format(
             self.tool, self.output_type, self.output_file, temp_name
         )
 


### PR DESCRIPTION
extra quotation marks cause silent failure on windows with invisible "The system cannot find the path specified."