### PR TITLE
Switch to `sys.setprofile` and make stdlib detection more robust.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     packages=['pycallgraph2', 'pycallgraph2.output'],
     scripts=['scripts/pycallgraph'],
     data_files=data_files,
-    use_2to3=True,
 
     # Testing
     tests_require=['pytest'],


### PR DESCRIPTION
Switch to sys.setprofile which should help limit the number of times the tracer is invoked.

Make the stdlib detection more robust, which should help prevent the tracer for inadvertently filtering out non stdlib code.