### PR TITLE
Fix stdlib checking; Make frames with no name filterable...

### DIFF
--- a/pycallgraph2/tracer.py
+++ b/pycallgraph2/tracer.py
@@ -192,7 +192,7 @@ class TraceProcessor(Thread):
             full_name_list.append(func_name)
 
             # Create a readable representation of the current call
-            full_name = '.'.join(full_name_list)
+            full_name = '.'.join(full_name_list) or ''
 
             if len(self.call_stack) > self.config.max_depth:
                 keep = False

--- a/pycallgraph2/tracer.py
+++ b/pycallgraph2/tracer.py
@@ -205,6 +205,9 @@ class TraceProcessor(Thread):
             # Store the call information
             if keep:
 
+                if self.config.verbose:
+                    print(frame, f"module name: {module_name}")
+
                 if self.call_stack:
                     src_func = self.call_stack[-1]
                 else:

--- a/pycallgraph2/tracer.py
+++ b/pycallgraph2/tracer.py
@@ -192,7 +192,7 @@ class TraceProcessor(Thread):
             full_name_list.append(func_name)
 
             # Create a readable representation of the current call
-            full_name = '.'.join(full_name_list) or ''
+            full_name = '.'.join(full_name_list) if module_name else ''
 
             if len(self.call_stack) > self.config.max_depth:
                 keep = False
@@ -206,7 +206,7 @@ class TraceProcessor(Thread):
             if keep:
 
                 if self.config.verbose:
-                    print(frame, f"module name: {module_name}")
+                    print(f"{frame}, module name: '{module_name}'")
 
                 if self.call_stack:
                     src_func = self.call_stack[-1]


### PR DESCRIPTION
### Explanation: 

- Standard library calls were not being filtered previously (with appropriate setting set), at least not from inside a virtualenv--but I don't think at all. This corrects that.
- I ran into some kind of problem with how module was being checked by `inspect`, and noticed that the `inspect.getmodule` call has been deprecated for a long time. That's why I replaced it with an up-to-date one.
- Finally, it's useful, when debugging why the wrong calls are being recorded, to know which ARE recorded. I added a print statement behind the `config.verbose` flag
 
